### PR TITLE
implement dsu

### DIFF
--- a/dsu/dsu.go
+++ b/dsu/dsu.go
@@ -1,0 +1,89 @@
+package dsu
+
+type DisjointSetUnion struct {
+	n            int
+	parentOrSize []int
+}
+
+func New(n int) *DisjointSetUnion {
+	d := &DisjointSetUnion{
+		n:            n,
+		parentOrSize: make([]int, n),
+	}
+	for i := range d.parentOrSize {
+		d.parentOrSize[i] = -1
+	}
+	return d
+}
+
+func (d *DisjointSetUnion) Merge(a, b int) int {
+	if !(0 <= a && a < d.n) {
+		panic("")
+	}
+	if !(0 <= b && b < d.n) {
+		panic("")
+	}
+	x, y := d.Leader(a), d.Leader(b)
+	if x == y {
+		return x
+	}
+	if -d.parentOrSize[x] < -d.parentOrSize[y] {
+		x, y = y, x
+	}
+	d.parentOrSize[x] += d.parentOrSize[y]
+	d.parentOrSize[y] = x
+	return x
+}
+
+func (d *DisjointSetUnion) Same(a, b int) bool {
+	if !(0 <= a && a < d.n) {
+		panic("")
+	}
+	if !(0 <= b && b < d.n) {
+		panic("")
+	}
+	return d.Leader(a) == d.Leader(b)
+}
+
+func (d *DisjointSetUnion) Leader(a int) int {
+	if !(0 <= a && a < d.n) {
+		panic("")
+	}
+	if d.parentOrSize[a] < 0 {
+		return a
+	}
+	d.parentOrSize[a] = d.Leader(d.parentOrSize[a])
+	return d.parentOrSize[a]
+}
+
+func (d *DisjointSetUnion) Size(a int) int {
+	if !(0 <= a && a < d.n) {
+		panic("")
+	}
+	return -d.parentOrSize[d.Leader(a)]
+}
+
+func (d *DisjointSetUnion) Groups() [][]int {
+	leaderBuf, groupSize := make([]int, d.n), make([]int, d.n)
+	for i := 0; i < d.n; i++ {
+		leaderBuf[i] = d.Leader(i)
+		groupSize[leaderBuf[i]]++
+	}
+	result := make([][]int, d.n)
+	for i := 0; i < d.n; i++ {
+		result[i] = make([]int, 0, groupSize[i])
+	}
+	for i := 0; i < d.n; i++ {
+		result[leaderBuf[i]] = append(result[leaderBuf[i]], i)
+	}
+	eraseEmpty := func(a [][]int) [][]int {
+		result := make([][]int, 0, len(a))
+		for i := range a {
+			if len(a[i]) != 0 {
+				result = append(result, a[i])
+			}
+		}
+		return result
+	}
+	return eraseEmpty(result)
+}

--- a/dsu/dsu_test.go
+++ b/dsu/dsu_test.go
@@ -1,0 +1,27 @@
+package dsu
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDisjointSetUnion(t *testing.T) {
+	d := New(4)
+	d.Merge(0, 1)
+	if !d.Same(0, 1) {
+		t.FailNow()
+	}
+	d.Merge(1, 2)
+	if !d.Same(1, 2) {
+		t.FailNow()
+	}
+	if !(d.Size(0) == 3) {
+		t.Fatal(d.Size(0))
+	}
+	if d.Same(0, 3) {
+		t.FailNow()
+	}
+	if g := d.Groups(); !reflect.DeepEqual(g, [][]int{{0, 1, 2}, {3}}) {
+		t.Fatal(g)
+	}
+}

--- a/dsu/dsu_test.go
+++ b/dsu/dsu_test.go
@@ -12,6 +12,9 @@ func TestDisjointSetUnion(t *testing.T) {
 		t.FailNow()
 	}
 	d.Merge(1, 2)
+	if !d.Same(0, 2) {
+		t.FailNow()
+	}
 	if !d.Same(1, 2) {
 		t.FailNow()
 	}


### PR DESCRIPTION
基本的にACLのC++版をそのまま写しました。
Groupsの空のvectorを削除するものだけ自前で書きました。

テストは[ac-library-rs](https://github.com/rust-lang-ja/ac-library-rs/blob/5103743e242264c473f1691e3380e25556198d4e/src/dsu.rs#L74)からいただきました。

Fixes #2 